### PR TITLE
clientv3: Add unix socket tests for new load balancer and resolver

### DIFF
--- a/clientv3/balancer/resolver/endpoint/endpoint.go
+++ b/clientv3/balancer/resolver/endpoint/endpoint.go
@@ -103,6 +103,19 @@ func (r *Resolver) InitialAddrs(addrs []resolver.Address) {
 	r.bootstrapAddrs = addrs
 }
 
+func (r *Resolver) InitialEndpoints(eps []string) {
+	r.InitialAddrs(epsToAddrs(eps...))
+}
+
+// TODO: use balancer.epsToAddrs
+func epsToAddrs(eps ...string) (addrs []resolver.Address) {
+	addrs = make([]resolver.Address, 0, len(eps))
+	for _, ep := range eps {
+		addrs = append(addrs, resolver.Address{Addr: ep})
+	}
+	return addrs
+}
+
 // NewAddress updates the addresses of the resolver.
 func (r *Resolver) NewAddress(addrs []resolver.Address) error {
 	if r.cc == nil {

--- a/clientv3/balancer/utils.go
+++ b/clientv3/balancer/utils.go
@@ -1,3 +1,17 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package balancer
 
 import (

--- a/clientv3/balancer/utils_test.go
+++ b/clientv3/balancer/utils_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package balancer
 
 import (


### PR DESCRIPTION
@gyuho I've hacked in a fix to `vendor/google.golang.org/grpc/clientconn.go` since https://github.com/grpc/grpc-go/pull/1883 is not yet available. Would you prefer I exclude that and comment out the test that will fail without it or leave it in?