### PR TITLE
clientv3: Split out grpc balancer builder

### DIFF
--- a/clientv3/balancer/resolver/endpoint/endpoint.go
+++ b/clientv3/balancer/resolver/endpoint/endpoint.go
@@ -112,8 +112,15 @@ func (r *Resolver) InitialAddrs(addrs []resolver.Address) {
 	r.Unlock()
 }
 
-func (r *Resolver) InitialEndpoints(eps []string) {
+// InitialEndpoints sets the initial endpoints to for the resolver and returns a grpc dial target.
+// This should be called before dialing. The endpoints may be updated after the dial using NewAddress.
+// At least one endpoint is required.
+func (r *Resolver) InitialEndpoints(eps []string) (string, error) {
+	if len(eps) < 1 {
+		return "", fmt.Errorf("At least one endpoint is required, but got: %v", eps)
+	}
 	r.InitialAddrs(epsToAddrs(eps...))
+	return r.Target(eps[0]), nil
 }
 
 // TODO: use balancer.epsToAddrs


### PR DESCRIPTION
Per discussion with grpc team (https://github.com/grpc/grpc-go/issues/1973#issuecomment-379974012) split out the balancer builder to ensure one balancer instance per `ClientConn`. I've validated this fixes the grpcproxy tests that were failing when we were using a single global balancer.

I've also cleaned up and simplified the client.go a bit. Conveniently, adopting this new balancer interface seems to be resulting in a net reduction of code in client.go.

cc @gyuho 