### PR TITLE
clientv3: Fix dialer for new balancer to use correct endpoints

### DIFF
--- a/clientv3/ordering/kv_test.go
+++ b/clientv3/ordering/kv_test.go
@@ -82,6 +82,7 @@ func TestDetectKvOrderViolation(t *testing.T) {
 	clus.Members[2].Restart(t)
 	// force OrderingKv to query the third member
 	cli.SetEndpoints(clus.Members[2].GRPCAddr())
+	time.Sleep(2 * time.Second) // FIXME: Figure out how pause SetEndpoints sufficiently that this is not needed
 
 	_, err = orderingKv.Get(ctx, "foo", clientv3.WithSerializable())
 	if err != errOrderViolation {
@@ -147,7 +148,7 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 	clus.Members[2].Restart(t)
 	// force OrderingKv to query the third member
 	cli.SetEndpoints(clus.Members[2].GRPCAddr())
-
+	time.Sleep(2 * time.Second) // FIXME: Figure out how pause SetEndpoints sufficiently that this is not needed
 	_, err = orderingKv.Get(ctx, "foo", clientv3.WithSerializable())
 	if err != errOrderViolation {
 		t.Fatalf("expected %v, got %v", errOrderViolation, err)


### PR DESCRIPTION
The new grpc balancer interface provides an address not a host to the 1st param of the dialer function `func(string, time.Duration)` passed in by `clientv3.dialSetupOpts` via `opts.Dialer` to `grpc.DialContext`.

With the old grpc balancer interface, the etcd clientv3 code was somehow able to assume it was a host and was able to map it to back to an endpoint, and only if that failed would it fallback to the the 0th endpoint in the list of endpoints the client was configured with. With the new grpc load balancer, this caused some of the ordering tests to fail with warnings like: 

```
WARNING: 2018/04/10 15:21:04 grpc: addrConn.createTransport failed to connect to {unix://localhost:82810032125410001560 0  <nil>}. Err :connection error: desc = "transport:  Error while dialing dial unix localhost:76598796135796877370: connect: no such file or directory". Reconnecting...
```

Note how there are two different unix sockets identified in the message. This is because the dialer is incorrectly using the fallback when it should not. This PR fixes dialer to always connect to the correct endpoint and changes warnings like this to correctly report the same unix socket in both places in the log string.  With this fix in place quite a few more tests are passing. The remaining failures are: `TestUnresolvableOrderViolation`, `TestTxnPanics`, `TestDialTimeout`, and `TestDialCancel`.

I've also added a balancer `id` to make it easier to debug balancer related issues when there are multiple balancers running concurrently.