### PR TITLE
clientv3: use "grpc.DialContext" to deprecate "grpc.WithTimeout", and fix dial tests

### DIFF
--- a/clientv3/auth.go
+++ b/clientv3/auth.go
@@ -216,8 +216,8 @@ func (auth *authenticator) close() {
 	auth.conn.Close()
 }
 
-func newAuthenticator(endpoint string, opts []grpc.DialOption, c *Client) (*authenticator, error) {
-	conn, err := grpc.Dial(endpoint, opts...)
+func newAuthenticator(ctx context.Context, endpoint string, opts []grpc.DialOption, c *Client) (*authenticator, error) {
+	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/clientv3/client_test.go
+++ b/clientv3/client_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/coreos/etcd/pkg/testutil"
+
+	"google.golang.org/grpc"
 )
 
 func TestDialCancel(t *testing.T) {
@@ -80,14 +82,17 @@ func TestDialCancel(t *testing.T) {
 func TestDialTimeout(t *testing.T) {
 	defer testutil.AfterTest(t)
 
+	// grpc.WithBlock to block until connection up or timeout
 	testCfgs := []Config{
 		{
 			Endpoints:   []string{"http://254.0.0.1:12345"},
 			DialTimeout: 2 * time.Second,
+			DialOptions: []grpc.DialOption{grpc.WithBlock()},
 		},
 		{
 			Endpoints:   []string{"http://254.0.0.1:12345"},
 			DialTimeout: time.Second,
+			DialOptions: []grpc.DialOption{grpc.WithBlock()},
 			Username:    "abc",
 			Password:    "def",
 		},


### PR DESCRIPTION
`(grpc.DialOption).grpc.WithTimeout` https://godoc.org/google.golang.org/grpc#WithTimeout is being deprecated, and also client dial unit tests have been broken. Replace `grpc.Dial` with `grpc.DialContext` to make dial block until the connection is up, and returns a context error if any.

ref. https://github.com/grpc/grpc-go/issues/1990.

/cc @jpbetz