### PR TITLE
clientv3: Fix balancer tests & avoid timeouts in ordering test

### DIFF
--- a/clientv3/balancer/balancer_test.go
+++ b/clientv3/balancer/balancer_test.go
@@ -67,13 +67,14 @@ func TestRoundRobinBalancedResolvableNoFailover(t *testing.T) {
 			defer rsv.Close()
 			rsv.InitialAddrs(resolvedAddrs)
 
+			name := genName()
 			cfg := Config{
 				Policy: picker.RoundrobinBalanced,
-				Name:   genName(),
+				Name:   name,
 				Logger: zap.NewExample(),
 			}
-			rrb := New(cfg)
-			conn, err := grpc.Dial(fmt.Sprintf("endpoint://nofailover/*"), grpc.WithInsecure(), grpc.WithBalancerName(rrb.Name()))
+			RegisterBuilder(cfg)
+			conn, err := grpc.Dial(fmt.Sprintf("endpoint://nofailover/*"), grpc.WithInsecure(), grpc.WithBalancerName(name))
 			if err != nil {
 				t.Fatalf("failed to dial mock server: %v", err)
 			}
@@ -129,13 +130,14 @@ func TestRoundRobinBalancedResolvableFailoverFromServerFail(t *testing.T) {
 	defer rsv.Close()
 	rsv.InitialAddrs(resolvedAddrs)
 
+	name := genName()
 	cfg := Config{
 		Policy: picker.RoundrobinBalanced,
-		Name:   genName(),
+		Name:   name,
 		Logger: zap.NewExample(),
 	}
-	rrb := New(cfg)
-	conn, err := grpc.Dial(fmt.Sprintf("endpoint://serverfail/mock.server"), grpc.WithInsecure(), grpc.WithBalancerName(rrb.Name()))
+	RegisterBuilder(cfg)
+	conn, err := grpc.Dial(fmt.Sprintf("endpoint://serverfail/mock.server"), grpc.WithInsecure(), grpc.WithBalancerName(name))
 	if err != nil {
 		t.Fatalf("failed to dial mock server: %s", err)
 	}
@@ -242,13 +244,14 @@ func TestRoundRobinBalancedResolvableFailoverFromRequestFail(t *testing.T) {
 	defer rsv.Close()
 	rsv.InitialAddrs(resolvedAddrs)
 
+	name := genName()
 	cfg := Config{
 		Policy: picker.RoundrobinBalanced,
-		Name:   genName(),
+		Name:   name,
 		Logger: zap.NewExample(),
 	}
-	rrb := New(cfg)
-	conn, err := grpc.Dial(fmt.Sprintf("endpoint://requestfail/mock.server"), grpc.WithInsecure(), grpc.WithBalancerName(rrb.Name()))
+	RegisterBuilder(cfg)
+	conn, err := grpc.Dial(fmt.Sprintf("endpoint://requestfail/mock.server"), grpc.WithInsecure(), grpc.WithBalancerName(name))
 	if err != nil {
 		t.Fatalf("failed to dial mock server: %s", err)
 	}

--- a/clientv3/ordering/util.go
+++ b/clientv3/ordering/util.go
@@ -43,6 +43,8 @@ func NewOrderViolationSwitchEndpointClosure(c clientv3.Client) OrderViolationFun
 		// set available endpoints back to all endpoints in to ensure
 		// the client has access to all the endpoints.
 		c.SetEndpoints(eps...)
+		// give enough time for operation
+		time.Sleep(1 * time.Second)
 		violationCount++
 		return nil
 	}

--- a/clientv3/ordering/util_test.go
+++ b/clientv3/ordering/util_test.go
@@ -142,8 +142,9 @@ func TestUnresolvableOrderViolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	clus.Members[3].WaitStarted(t)
 	cli.SetEndpoints(clus.Members[3].GRPCAddr())
-	time.Sleep(1 * time.Second) // give enough time for operation
+	time.Sleep(5 * time.Second) // give enough time for operation
 
 	_, err = OrderingKv.Get(ctx, "foo", clientv3.WithSerializable())
 	if err != ErrNoGreaterRev {

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -804,6 +804,13 @@ func (m *member) Launch() error {
 }
 
 func (m *member) WaitOK(t *testing.T) {
+	m.WaitStarted(t)
+	for m.s.Leader() == 0 {
+		time.Sleep(tickDuration)
+	}
+}
+
+func (m *member) WaitStarted(t *testing.T) {
 	cc := MustNewHTTPClient(t, []string{m.URL()}, m.ClientTLSInfo)
 	kapi := client.NewKeysAPI(cc)
 	for {
@@ -816,9 +823,7 @@ func (m *member) WaitOK(t *testing.T) {
 		cancel()
 		break
 	}
-	for m.s.Leader() == 0 {
-		time.Sleep(tickDuration)
-	}
+
 }
 
 func (m *member) URL() string { return m.ClientURLs[0].String() }


### PR DESCRIPTION
With these fixes in place, `./test` is passing for me consistently.

With the clientv3 integration with the old grpc load balancer interface, `SetEndpoints` would block until the endpoint update was propagated. When upgrading to the new load balancer interface, we didn't have anything to replace that block with.  I've partially mitigated the flakiness this can cause in tests by introducing a `lus.Members[3].WaitStarted(t)` wait before the last `SetEndpoints` call in `TestUnresolvableOrderViolation` which was otherwise failing consistently, but even with that in place, the `time.Sleep(5 * time.Second)` was needed to prevent the final `Get` call from timing out. That should not be needed--we should be able to set an appropriate timeout to avoid this and reduce flakiness in general...