### PR TITLE
clientv3: remove unused "dialerrc"

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -64,8 +64,7 @@ type Client struct {
 	Auth
 	Maintenance
 
-	conn     *grpc.ClientConn
-	dialerrc chan error
+	conn *grpc.ClientConn
 
 	cfg           Config
 	creds         *credentials.TransportCredentials
@@ -250,14 +249,7 @@ func (c *Client) dialSetupOpts(target string, dopts ...grpc.DialOption) (opts []
 		default:
 		}
 		dialer := &net.Dialer{Timeout: t}
-		conn, err := dialer.DialContext(c.ctx, proto, host)
-		if err != nil {
-			select {
-			case c.dialerrc <- err:
-			default:
-			}
-		}
-		return conn, err
+		return dialer.DialContext(c.ctx, proto, host)
 	}
 	opts = append(opts, grpc.WithDialer(f))
 
@@ -395,7 +387,6 @@ func newClient(cfg *Config) (*Client, error) {
 	ctx, cancel := context.WithCancel(baseCtx)
 	client := &Client{
 		conn:     nil,
-		dialerrc: make(chan error, 1),
 		cfg:      *cfg,
 		creds:    creds,
 		ctx:      ctx,


### PR DESCRIPTION
Errors such as

```
dial tcp 254.0.0.1:12345: connect: network is unreachable
```

was being sent to `dialerrc` but never used. And will not be used.

User can just provide context timeouts and expects `context deadline exceeded` errors from `clientv3.New`, by specifying:

```
DialTimeout: time.Second,
DialOptions: []grpc.DialOption{grpc.WithBlock()},
```

e.g. [`TestDialTimeout`](https://github.com/coreos/etcd/blob/b91ed542a6c797115d8bf29019878571a881614a/clientv3/client_test.go#L80) in `clientv3`