### PR TITLE
clientv3: Provide host only target to grpc DialContext, fix integration tests to block on dial when needed

### DIFF
--- a/clientv3/balancer/resolver/endpoint/endpoint.go
+++ b/clientv3/balancer/resolver/endpoint/endpoint.go
@@ -146,8 +146,19 @@ func (r *Resolver) Close() {
 	bldr.removeResolver(r)
 }
 
+// Target constructs a endpoint target with current resolver's clusterName.
 func (r *Resolver) Target(endpoint string) string {
-	return fmt.Sprintf("%s://%s/%s", scheme, r.clusterName, endpoint)
+	return Target(r.clusterName, endpoint)
+}
+
+// Target constructs a endpoint resolver target.
+func Target(clusterName, endpoint string) string {
+	return fmt.Sprintf("%s://%s/%s", scheme, clusterName, endpoint)
+}
+
+// IsTarget checks if a given target string in an endpoint resolver target.
+func IsTarget(target string) bool {
+	return strings.HasPrefix(target, "endpoint://")
 }
 
 // Parse endpoint parses a endpoint of the form (http|https)://<host>*|(unix|unixs)://<path>) and returns a

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -513,6 +513,7 @@ type member struct {
 	PeerTLSInfo *transport.TLSInfo
 	// ClientTLSInfo enables client TLS when set
 	ClientTLSInfo *transport.TLSInfo
+	DialOptions   []grpc.DialOption
 
 	raftHandler   *testutil.PauseableHandler
 	s             *etcdserver.EtcdServer
@@ -681,6 +682,9 @@ func NewClientV3(m *member) (*clientv3.Client, error) {
 			return nil, err
 		}
 		cfg.TLS = tls
+	}
+	if m.DialOptions != nil {
+		cfg.DialOptions = append(cfg.DialOptions, m.DialOptions...)
 	}
 	return newClientV3(cfg)
 }

--- a/integration/v3_alarm_test.go
+++ b/integration/v3_alarm_test.go
@@ -191,10 +191,12 @@ func TestV3CorruptAlarm(t *testing.T) {
 	}
 	// Member 0 restarts into split brain.
 
+	clus.Members[0].WaitStarted(t)
 	resp0, err0 := clus.Client(0).Get(context.TODO(), "abc")
 	if err0 != nil {
 		t.Fatal(err0)
 	}
+	clus.Members[1].WaitStarted(t)
 	resp1, err1 := clus.Client(1).Get(context.TODO(), "abc")
 	if err1 != nil {
 		t.Fatal(err1)

--- a/integration/v3_grpc_test.go
+++ b/integration/v3_grpc_test.go
@@ -1570,6 +1570,7 @@ func TestTLSGRPCRejectSecureClient(t *testing.T) {
 	defer clus.Terminate(t)
 
 	clus.Members[0].ClientTLSInfo = &testTLSInfo
+	clus.Members[0].DialOptions = []grpc.DialOption{grpc.WithBlock()}
 	client, err := NewClientV3(clus.Members[0])
 	if client != nil || err == nil {
 		t.Fatalf("expected no client")
@@ -1752,6 +1753,7 @@ func testTLSReload(
 				continue
 			}
 			cli, cerr := clientv3.New(clientv3.Config{
+				DialOptions: []grpc.DialOption{grpc.WithBlock()},
 				Endpoints:   []string{clus.Members[0].GRPCAddr()},
 				DialTimeout: time.Second,
 				TLS:         cc,


### PR DESCRIPTION
Fixes all but the `TestV3CorruptAlarm` integration test failure, which I'm looking in to now.

I'm still concerned that the fix to the `TestV3KVInflightRangeRequests` here might not be correct. Switching the order of `clus.Members[0].Stop(t)` and `cancel()` also results in this test passing again, but I feel I might be missing some context on why this test was written the way it was.