### PR TITLE
clientv3: Fix dial calls to consistently use endpoint resolver, attempt to deflake alarm test

### DIFF
--- a/clientv3/balancer/resolver/endpoint/endpoint.go
+++ b/clientv3/balancer/resolver/endpoint/endpoint.go
@@ -110,15 +110,15 @@ func (r *Resolver) InitialAddrs(addrs []resolver.Address) {
 	r.Unlock()
 }
 
-// InitialEndpoints sets the initial endpoints to for the resolver and returns a grpc dial target.
+// InitialEndpoints sets the initial endpoints to for the resolver.
 // This should be called before dialing. The endpoints may be updated after the dial using NewAddress.
 // At least one endpoint is required.
-func (r *Resolver) InitialEndpoints(eps []string) (string, error) {
+func (r *Resolver) InitialEndpoints(eps []string) error {
 	if len(eps) < 1 {
-		return "", fmt.Errorf("At least one endpoint is required, but got: %v", eps)
+		return fmt.Errorf("At least one endpoint is required, but got: %v", eps)
 	}
 	r.InitialAddrs(epsToAddrs(eps...))
-	return r.Target(eps[0]), nil
+	return nil
 }
 
 // TODO: use balancer.epsToAddrs

--- a/clientv3/maintenance.go
+++ b/clientv3/maintenance.go
@@ -16,6 +16,7 @@ package clientv3
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
@@ -77,7 +78,7 @@ func NewMaintenance(c *Client) Maintenance {
 		dial: func(endpoint string) (pb.MaintenanceClient, func(), error) {
 			conn, err := c.dial(endpoint)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, fmt.Errorf("failed to dial endpoint %s with maintenance client: %v", endpoint, err)
 			}
 			cancel := func() { conn.Close() }
 			return RetryMaintenanceClient(c, conn), cancel, nil
@@ -175,6 +176,7 @@ func (m *maintenance) Status(ctx context.Context, endpoint string) (*StatusRespo
 func (m *maintenance) HashKV(ctx context.Context, endpoint string, rev int64) (*HashKVResponse, error) {
 	remote, cancel, err := m.dial(endpoint)
 	if err != nil {
+
 		return nil, toErr(ctx, err)
 	}
 	defer cancel()


### PR DESCRIPTION
Fixes `TestV3CorruptAlarm` integration test failure by making sure that endpoints are mapped to targets from all callsights to `clientv3.dial()` by moving the mapping into the function. In particular, this fixes the call from `maintenance.go` which was causing `cli.HashKV()` call to silently fail, preventing corruption checks from occurring.  This also fixes `client.Dial()`.

In debugging `TestV3CorruptAlarm` I also added some additional error checks and state transition waits to help reduce the flakiness of the test.  There is still work to do to remove the Sleep calls, which should not be needed. But after these tweaks, the test at least no longer flakes on my development machine.