### PR TITLE
clientv3: Stop expecting retry in integration tests with new grpc balancer

### DIFF
--- a/clientv3/integration/dial_test.go
+++ b/clientv3/integration/dial_test.go
@@ -156,6 +156,10 @@ func TestSwitchSetEndpoints(t *testing.T) {
 	clus.Members[0].InjectPartition(t, clus.Members[1:]...)
 
 	cli.SetEndpoints(eps...)
+
+	// TODO: Remove wait once the new grpc load balancer provides retry.
+	integration.WaitClientV3(t, cli)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if _, err := cli.Get(ctx, "foo"); err != nil {

--- a/clientv3/integration/lease_test.go
+++ b/clientv3/integration/lease_test.go
@@ -292,10 +292,10 @@ func TestLeaseGrantErrConnClosed(t *testing.T) {
 	go func() {
 		defer close(donec)
 		_, err := cli.Grant(context.TODO(), 5)
-		if err != nil && err != grpc.ErrClientConnClosing && err != context.Canceled {
+		if err != nil && err != grpc.ErrClientConnClosing && err != context.Canceled && !isServerUnavailable(err) {
 			// grpc.ErrClientConnClosing if grpc-go balancer calls 'Get' after client.Close.
 			// context.Canceled if grpc-go balancer calls 'Get' with an inflight client.Close.
-			t.Fatalf("expected %v or %v, got %v", grpc.ErrClientConnClosing, context.Canceled, err)
+			t.Fatalf("expected %v, %v or server unavailable, got %v", err != context.Canceled, grpc.ErrClientConnClosing, err)
 		}
 	}()
 
@@ -324,8 +324,8 @@ func TestLeaseGrantNewAfterClose(t *testing.T) {
 
 	donec := make(chan struct{})
 	go func() {
-		if _, err := cli.Grant(context.TODO(), 5); err != context.Canceled && err != grpc.ErrClientConnClosing {
-			t.Fatalf("expected %v or %v, got %v", err != context.Canceled, grpc.ErrClientConnClosing, err)
+		if _, err := cli.Grant(context.TODO(), 5); err != context.Canceled && err != grpc.ErrClientConnClosing && !isServerUnavailable(err) {
+			t.Fatalf("expected %v, %v or server unavailable, got %v", err != context.Canceled, grpc.ErrClientConnClosing, err)
 		}
 		close(donec)
 	}()
@@ -356,8 +356,8 @@ func TestLeaseRevokeNewAfterClose(t *testing.T) {
 
 	donec := make(chan struct{})
 	go func() {
-		if _, err := cli.Revoke(context.TODO(), leaseID); err != context.Canceled && err != grpc.ErrClientConnClosing {
-			t.Fatalf("expected %v or %v, got %v", err != context.Canceled, grpc.ErrClientConnClosing, err)
+		if _, err := cli.Revoke(context.TODO(), leaseID); err != context.Canceled && err != grpc.ErrClientConnClosing && !isServerUnavailable(err) {
+			t.Fatalf("expected %v, %v or server unavailable, got %v", err != context.Canceled, grpc.ErrClientConnClosing, err)
 		}
 		close(donec)
 	}()

--- a/clientv3/integration/maintenance_test.go
+++ b/clientv3/integration/maintenance_test.go
@@ -156,9 +156,11 @@ func TestMaintenanceSnapshotErrorInflight(t *testing.T) {
 	b.Close()
 	clus.Members[0].Restart(t)
 
+	cli := clus.RandClient()
+	integration.WaitClientV3(t, cli)
 	// reading snapshot with canceled context should error out
 	ctx, cancel := context.WithCancel(context.Background())
-	rc1, err := clus.RandClient().Snapshot(ctx)
+	rc1, err := cli.Snapshot(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/clientv3/integration/txn_test.go
+++ b/clientv3/integration/txn_test.go
@@ -79,6 +79,9 @@ func TestTxnWriteFail(t *testing.T) {
 			t.Fatalf("timed out waiting for txn fail")
 		case <-txnc:
 		}
+		// TODO: Remove wait once the new grpc load balancer provides retry.
+		integration.WaitClientV3(t, kv)
+
 		// and ensure the put didn't take
 		gresp, gerr := clus.Client(1).Get(context.TODO(), "foo")
 		if gerr != nil {
@@ -90,7 +93,7 @@ func TestTxnWriteFail(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(2 * clus.Members[1].ServerConfig.ReqTimeout()):
+	case <-time.After(5 * clus.Members[1].ServerConfig.ReqTimeout()):
 		t.Fatalf("timed out waiting for get")
 	case <-getc:
 	}

--- a/clientv3/options.go
+++ b/clientv3/options.go
@@ -21,12 +21,11 @@ import (
 )
 
 var (
-	// Disable gRPC internal retrial logic
-	// TODO: enable when gRPC retry is stable (FailFast=false)
-	// Reference:
-	//  - https://github.com/grpc/grpc-go/issues/1532
-	//  - https://github.com/grpc/proposal/blob/master/A6-client-retries.md
-	defaultFailFast = grpc.FailFast(true)
+	// client-side handling retrying of request failures where data was not written to the wire or
+	// where server indicates it did not process the data. gPRC default is default is "FailFast(true)"
+	// but for etcd we default to "FailFast(false)" to minimize client request error responses due to
+	// transident failures.
+	defaultFailFast = grpc.FailFast(false)
 
 	// client-side request send limit, gRPC default is math.MaxInt32
 	// Make sure that "client-side send limit < server-side default send/recv limit"

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -940,7 +940,23 @@ func (m *member) WaitStarted(t *testing.T) {
 		cancel()
 		break
 	}
+}
 
+func WaitClientV3(t *testing.T, kv clientv3.KV) {
+	timeout := time.Now().Add(requestTimeout)
+	var err error
+	for time.Now().Before(timeout) {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		_, err := kv.Get(ctx, "/")
+		cancel()
+		if err == nil {
+			return
+		}
+		time.Sleep(tickDuration)
+	}
+	if err != nil {
+		t.Fatalf("timed out waiting for client: %v", err)
+	}
 }
 
 func (m *member) URL() string { return m.ClientURLs[0].String() }


### PR DESCRIPTION
Set `grpc.FailFast(false)` since the behavior now seems safe/correct.

Another round of integration test cleanup.

- Fix tests that assumed client retry to work with new balancer, either by adding an explicit retry loop or waiting for the client to first establish a ready connection
- Switch to checking for `isServerUnavailable` to determine if the leasing client has acknowledged a lost lease. With the new grpc load balancer API, when the server is stopped, the leasing client's session promptly transitions to 'not ready' and all subsequent client calls bypass the leasing cache and are sent directly grpc client, which returns an Unavailable error. I don't fully understand why context canceled was returned with the old balancer, but an unavailable error does indicate that the leasing client attempted to contact the server rather than relying on it's lease cache, which should be sufficient for the `waitForExpireAck` check?
- Fixed test that assumed pinning to instead expect round robin load balancing-  `TestBalancerUnderNetworkPartitionLinearizableGetLeaderElection`

With these fixes in place the `clientv3/integration` is passing consistently with no consistent failures and no obvious flakes on my dev box (previous flakes are now passing `-count 7` test runs).