### PR TITLE
clientv3/integration: Add err check to TestDialTLSNoConfig to prevent nil pointer dereference on c.Close()

### DIFF
--- a/clientv3/integration/dial_test.go
+++ b/clientv3/integration/dial_test.go
@@ -79,6 +79,9 @@ func TestDialTLSNoConfig(t *testing.T) {
 		DialTimeout: time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer c.Close()
 
 	// TODO: this should not be required when we set grpc.WithBlock()


### PR DESCRIPTION
fixes:

```
=== RUN   TestDialTLSNoConfig
 WARNING: 2018/05/24 11:31:58 grpc: Server.Serve failed to complete security handshake from "@": tls: first record does not look like a TLS handshake
 WARNING: 2018/05/24 11:31:59 grpc: addrConn.transportMonitor exits due to: context canceled
 --- FAIL: TestDialTLSNoConfig (1.18s)
 panic: runtime error: invalid memory address or nil pointer dereference [recovered]
     panic: runtime error: invalid memory address or nil pointer dereference
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x140 pc=0xc06d79]

 goroutine 3273 [running]:
 testing.tRunner.func1(0xc420374870)
     /usr/local/go/src/testing/testing.go:742 +0x567
 panic(0x1386060, 0x1ca95a0)
     /usr/local/go/src/runtime/panic.go:502 +0x24a
 github.com/coreos/etcd/clientv3.(*Client).Close(0x0, 0x0, 0x3b9aca00)
     /home/gyuho/go/src/github.com/coreos/etcd/clientv3/client.go:120 +0x49
 github.com/coreos/etcd/clientv3/integration.TestDialTLSNoConfig(0xc420374870)
     /home/gyuho/go/src/github.com/coreos/etcd/clientv3/integration/dial_test.go:93 +0x413
 testing.tRunner(0xc420374870, 0x1531eb0)
     /usr/local/go/src/testing/testing.go:777 +0x16e
 created by testing.(*T).Run
     /usr/local/go/src/testing/testing.go:824 +0x565
 FAIL    github.com/coreos/etcd/clientv3/integration 62.899s
```