### PR TITLE
clientv3: Enable balancer logging if ETCD_CLIENT_DEBUG environment variable is set

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -49,13 +50,18 @@ var (
 )
 
 func init() {
+	lg := zap.NewNop()
+	if os.Getenv("ETCD_CLIENT_DEBUG") != "" {
+		var err error
+		lg, err = zap.NewProductionConfig().Build() // info level logging
+		if err != nil {
+			panic(err)
+		}
+	}
 	balancer.RegisterBuilder(balancer.Config{
 		Policy: picker.RoundrobinBalanced,
 		Name:   roundRobinBalancerName,
-
-		// TODO: configure from clientv3.Config
-		Logger: zap.NewNop(),
-		// Logger: zap.NewExample(),
+		Logger: lg,
 	})
 }
 

--- a/clientv3/config.go
+++ b/clientv3/config.go
@@ -76,7 +76,7 @@ type Config struct {
 
 	// LogConfig configures client-side logger.
 	// If nil, use the default logger.
-	// TODO: configure balancer and gRPC logger
+	// TODO: configure gRPC logger
 	LogConfig *zap.Config
 }
 

--- a/clientv3/doc.go
+++ b/clientv3/doc.go
@@ -99,4 +99,8 @@
 //		}
 //	}
 //
+// The grpc load balancer is registered statically and is shared across etcd clients.
+// To enable detailed load balancer logging, set the ETCD_CLIENT_DEBUG environment
+// variable.  E.g. "ETCD_CLIENT_DEBUG=1".
+//
 package clientv3


### PR DESCRIPTION
Unfortunately, grpc's new balancer design expects balancers to be registered global on init, which limits our options when it comes to things like configuring the logger used by the balancer.

This allows us to enable the balancers logger if the `ETCD_CLIENT_DEBUG` flag is set.